### PR TITLE
KR-313 Expire gcloud SSH key shortly after the job generates it

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -90,6 +90,7 @@ runs:
     - name: Deploy
       run: |
         gcloud compute ssh ${{ inputs.gcp-instance-name }} \
+          --ssh-key-expire-after 30s \
           --zone=${{ inputs.gcp-instance-zone }} \
           --project=${{ inputs.gcp-project-id }} \
           --tunnel-through-iap \


### PR DESCRIPTION
Every time `gcloud compute ssh` is used in an Action, a new ssh key is generated. On individual's machines, the same ssh key is stored locally and used if it already exists. But in Actions, that doesn't exist, so a new one is generated every time.

This works for a while, until 32 KiB of data in the form ssh keys (I think just fingerprints of them) has been added to the GCP service account's profile, then no more can be created, and deployment fails.

This change instructs GCP to expire the key after 30 seconds, which should be plenty of time for the Action to get connected.

After this is live, the existing profiles can be cleaned up with the following:

```sh
# Impersonate the service account
gcloud config set auth/impersonate_service_account services-deployment@project.iam.gserviceaccount.com

# Remove all of its ssh keys
for i in $(gcloud compute os-login ssh-keys list | grep -v FINGERPRINT); do echo $i; gcloud compute os-login ssh-keys remove --key $i; done

# Stop impersonating
gcloud config unset auth/impersonate_service_account
```